### PR TITLE
onetime.tgz enhancements - second try

### DIFF
--- a/etc/rc.flashrd.conf
+++ b/etc/rc.flashrd.conf
@@ -27,6 +27,12 @@ if mount | grep root_device | grep -qv read-only; then
   tar xpzf /flash/onetime.tgz -C /
   touch /etc/.flashrd_onetime
   echo flashrd: onetime extracted
+
+  if [ -e /flashrd.site ]; then
+   . /flashrd.site
+   echo flashrd: ran flashrd.site
+  fi
+
   echo rebooting
   sync; sync
   reboot


### PR DESCRIPTION
This patch only checks that / is mounted rw and then for /flashrd.site.  I think it is more correct this time.
