### PR TITLE
Add -fsd option to mount /flash as softdep.

### DIFF
--- a/flashrd
+++ b/flashrd
@@ -9,7 +9,7 @@ arch=`uname -m`
 vers=1.6
 
 typeset -x device rootdevice blocks rdroot dest vnddirs vndsize
-typeset -x tardirs tmpfsdirs totalsize
+typeset -x tardirs tmpfsdirs totalsize flashsoftdep
 typeset -x bytessec vnd distloc tmpmnt TMPDIR elfrdsetrootdir
 
 device=vnd3				# least likely to conflict ?
@@ -17,6 +17,7 @@ rootdevice=vnd2				# used to mount flash vnd
 blocks=4600				# blocks to reserve for kernel ramdisk
 rdroot=rd.$arch-$date			# ramdisk root fs image
 dest=flashimg.$arch-$date		# final product
+flashsoftdep=""				# mount option for softdep /flash
 
 # See ./etc/rc.flashrd.sub to define tardirs, vnddirs, tmpfsdirs
 #
@@ -58,6 +59,7 @@ Write to disk image:
 
 Other options:
     -e "dir"    directory where elfrdsetroot.c is located
+    -fsd        mount /flash with softdep (helpful for slow flash media)
 
 EOF
 }
@@ -70,6 +72,7 @@ do
   -l) t2 "$2"; totalsize="$2"; shift 2;;
   -b) t2 "$2"; bytessec="$2"; shift 2;;
   -e) t2 "$2"; elfrdsetrootdir="$2"; shift 2;;
+  -fsd) flashsoftdep="softdep,"; shift;;
 
   --) shift; break;;
   -*) usage; exit 1;;

--- a/mkrdroot
+++ b/mkrdroot
@@ -225,7 +225,7 @@ echo
 
 c 2 cp etc/rc $tmpmntdir/etc/rc
 
-c 2 cp stand/rc $tmpmntdir/stand/rc
+c 2 sed "/^flashsoftdep=/s/flashsoftdep=\"\"/flashsoftdep=\"${flashsoftdep}\"/" stand/rc > $tmpmntdir/stand/rc && chmod 755 $tmpmntdir/stand/rc
 
 umountwait 1 $tmpmntdir
 

--- a/stand/rc
+++ b/stand/rc
@@ -26,6 +26,7 @@ vnddirs="root bin etc sbin usr" # vnd0a, vnd0d, vnd0e, vnd0f, vnd0g
 set -A part a d e f g h i j k l m n o p
 vnd=vnd0
 disk=auto
+flashsoftdep=""
 
 export PATH=/bin:/sbin:/stand
 
@@ -127,7 +128,7 @@ if ! fsck -p /dev/$disk; then
   rdonly=",rdonly"
  fi
 fi
-if ! mount -o noatime,nodev,nosuid$rdonly /dev/$disk /flash; then
+if ! mount -o ${flashsoftdep}noatime,nodev,nosuid$rdonly /dev/$disk /flash; then
  echo bootstrap: fatal error mounting $disk to /flash
  exit 1
 fi


### PR DESCRIPTION
- Helpful for slow flash media.
- Off by default.
