### PR TITLE
Relocate resolv.conf from /etc to /var/db to allow dhclient to update it...

### DIFF
--- a/mkdist
+++ b/mkdist
@@ -76,6 +76,13 @@ if [ ! -z "tardirs" ]; then
  done
 fi
 
+# Relocate resolv.conf from /etc to /var/db to allow updates by dhclient
+# It doesn't exist in a fresh set, but check in case it was pre-populated
+if [ -f ${distloc}/etc/resolv.conf ]; then
+  mv ${distloc}/etc/resolv.conf ${distloc}/var/db
+fi
+ln -s /var/db/resolv.conf ${distloc}/etc
+
 ###
 #
 # disktab dance


### PR DESCRIPTION
... at any time, fixes #23.
- Even though resolv.conf is not included in a fresh set, check for it and move it in case it was pre-populated by a user.
- Verified dhclient will correctly follow a symlink if the destination resolv.conf doesn't exist yet.
