### PR TITLE
Make myname edit more likely to run on a vanilla tgz unpacking

### DIFF
--- a/mkdist
+++ b/mkdist
@@ -234,13 +234,13 @@ for i in $vnddirs; do
   # random.seed rests at /flash/etc/random.seed
   ln -fs /flash/etc/random.seed ${tmpmntdir}/random.seed
 
-  if [ ! -f ${tmpmntdir}/myname ]; then
+  if [ ! -f ${tmpmntdir}/myname -o "$(grep noname.my.domain ${tmpmntdir}/myname 2>/dev/null)" ]; then
    # No name? Let's call it 'flashrd' for now...
    c 2 echo flashrd > ${tmpmntdir}/myname
 
    if [ -f ${tmpmntdir}/hosts ]; then
     # Add 'flashrd' to the hosts file
-    c 2 sed -e 's/localhost/localhost flashrd/' < ${tmpmntdir}/hosts > ${tmpmntdir}/hosts.new
+    c 2 sed -e 's/localhost/localhost\ flashrd/' < ${tmpmntdir}/hosts > ${tmpmntdir}/hosts.new
     c 2 mv ${tmpmntdir}/hosts.new ${tmpmntdir}/hosts
    else
     # Create a basic hosts file


### PR DESCRIPTION
I can't speak for 5.7, but 5.6 has a default myname of noname.my.domain, making the affected block unlikely to run unless someone has intentionally pruned it. Make it run on pristine unpacked tgz's.