### PR TITLE
Build ramdisk binaries without PIE and restore bootability of i386

### DIFF
--- a/mkrdroot
+++ b/mkrdroot
@@ -167,6 +167,23 @@ cd $wd
 
 echo -n "Crunchgen ($progs)"
 cgdir=$(c 2 mktemp -t -d mkrdrootcg.XXXXXX)
+
+# Due to static PIE, ramdisk binaries need to be cleaned and rebuilt NOPIE
+c 2 cp -p /usr/src/bin/Makefile.inc /usr/src/bin/Makefile.inc.orig
+c 2 echo 'NOPIE=' >> /usr/src/bin/Makefile.inc
+c 2 cp -p /usr/src/sbin/Makefile.inc /usr/src/sbin/Makefile.inc.orig
+c 2 echo 'NOPIE=' >> /usr/src/sbin/Makefile.inc
+# These aren't cleaned by crunchgen's Makefile, do them manually
+for progname in ${progs}; do
+ if [ -d /usr/src/bin/${progname} ]; then
+  c 2 cd /usr/src/bin/${progname}
+  c 2 make clean > /dev/null
+ else
+  c 2 cd /usr/src/sbin/${progname}
+  c 2 make clean > /dev/null
+ fi
+done
+
 cat  <<-_EOF >>$cgdir/kcopy.conf
 srcdirs /usr/src/bin /usr/src/sbin
 
@@ -184,6 +201,18 @@ c 2 "crunchgen -Em Makefile $cgdir/kcopy.conf > $TMPDIR/last.output 2>&1"
 c 2 "make clean > $TMPDIR/last.output 2>&1"
 c 2 "make objs > $TMPDIR/last.output 2>&1"
 c 2 "make > $TMPDIR/last.output 2>&1"
+c 2 mv /usr/src/bin/Makefile.inc.orig /usr/src/bin/Makefile.inc
+c 2 mv /usr/src/sbin/Makefile.inc.orig /usr/src/sbin/Makefile.inc
+# Don't leave non-PIE .o hanging around
+for progname in ${progs}; do
+ if [ -d /usr/src/bin/${progname} ]; then
+  c 2 cd /usr/src/bin/${progname}
+  c 2 make clean > /dev/null
+ else
+  c 2 cd /usr/src/sbin/${progname}
+  c 2 make clean > /dev/null
+ fi
+done
 c 2 cd $wd
 echo
 


### PR DESCRIPTION
- Initially attempted to build using /usr/src/distrib/special to mirror ramdisk_cd use, but init and others were too customized, so borrowed the 'NOPIE=' approach.
- I think it was by chance that amd64 worked already, this is probably correct for both arches, as both use NOPIE for ramdisk_cd.
- Tested on i386 and amd64.

Closes #30.
