### PR TITLE
Clean up stderr on NOPIE sed

### DIFF
--- a/mkrdroot
+++ b/mkrdroot
@@ -194,7 +194,7 @@ libs -lutil
 c 2 cd $cgdir
 c 2 "crunchgen -Em Makefile $cgdir/kcopy.conf > $TMPDIR/last.output 2>&1"
 # Ramdisk binaries need to be built NOPIE
-sed -e "/^.*cd .* && exec $(MAKE)/s/exec/exec env NOPIE=/" Makefile > Makefile.tmp
+sed -e "/^.*cd .* && exec .* Makefile/s/exec/exec env NOPIE=/" Makefile > Makefile.tmp
 c 2 mv Makefile.tmp Makefile
 c 2 "make clean > $TMPDIR/last.output 2>&1"
 c 2 "make objs > $TMPDIR/last.output 2>&1"


### PR DESCRIPTION
- I could swear this didn't display an error before, even though I thought it should. The sed stills runs correctly, but ksh wants to run a non-existent $(MAKE).
- Updated the sed match to be equally specific.
- Tested and tested.
