### PR TITLE
4 MB is the new 1 MB is the new 64 sectors

### DIFF
--- a/growimg
+++ b/growimg
@@ -230,7 +230,7 @@ fi
 
 c 1 mount -o rdonly /dev/"$rootdevice"a $OldDir
 
-offset=64
+offset=$((4*1024*1024/${bytessec}))
 asize=$((totalsize - offset))
 
 echo "vnd-${tabname}:\\" > $NewLabel

--- a/mkboot
+++ b/mkboot
@@ -91,7 +91,7 @@ else
 fi
 
 # Main partition comprises the total disk after offset
-offset=64
+offset=$((4*1024*1024/${bytessec}))
 asize=$((totalsize - offset))
 
 echo "vnd-${tabname}:\\" > $tmplabel


### PR DESCRIPTION
- Align disk/image to 4 MiB for mkboot and growimg, taking into account sector size. This is especially important for cheap flash (see background).
- Ramdisk and openbsd.vnd remain untouched with 0 and 64 offsets, respectively.
- Tested mkboot on i386 and amd64.
- Personal note: I've been using this on manually-configured OpenBSD and Linux for years without issue.

Background:
- https://lwn.net/Articles/428584/ (see Partitioning, Future work, and comments re: alignment)
- https://lists.gnu.org/archive/html/bug-parted/2013-01/msg00000.html
