### PR TITLE
Fix mount options for /etc and /sbin during stand/rc hand-off

### DIFF
--- a/stand/rc
+++ b/stand/rc
@@ -52,7 +52,14 @@ mkvndmnt()
    fi
   fi
 
-  if ! mount -o noatime /dev/$dev /$i; then
+  # /etc is held open by /etc/rc umount/mount -a, give it the correct mount opts
+  if [ ${i} == "etc" ]; then
+   NOSUID=",nosuid"
+  else
+   NOSUID=
+  fi
+
+  if ! mount -o noatime,nodev${NOSUID} /dev/$dev /$i; then
    fail=1
   fi
 


### PR DESCRIPTION
While experimenting with full read-only configurations, I noticed that /sbin and /etc were not using the correct mount options from fstab, presumably due to being held open during /etc/rc umount-mount -a.

- Default vnd mounts to noatime,nodev which conforms to existing fstab defaults.
- Check for /etc specifically and add nosuid.

Before:
$ mount|egrep "(etc|sbin)"
/dev/vnd0e on /etc type ffs (local, noatime, read-only)
/dev/vnd0f on /sbin type ffs (local, noatime, read-only)

After:
$ mount|egrep "(etc|sbin)"
/dev/vnd0e on /etc type ffs (local, noatime, nodev, nosuid, read-only)
/dev/vnd0f on /sbin type ffs (local, noatime, nodev, read-only)
