### PR TITLE
All the math for filesystem size rely on "du" returning sizes in block.

### DIFF
--- a/etc/mtree.flashrd.conf
+++ b/etc/mtree.flashrd.conf
@@ -1,5 +1,5 @@
 #	$OpenBSD: 4.4BSD.dist,v 1.269 2014/12/22 15:39:28 tedu Exp $
-# 
+#
 # mtree.flashrd.conf ensure that all the directores in /var are present
 # with the right owner and rights.
 #

--- a/etc/rc.flashrd.conf
+++ b/etc/rc.flashrd.conf
@@ -8,6 +8,7 @@
 
 # ensure /var is conform to OpenBSD standard
 mtree -def /etc/mtree/flashrd.conf -u >/dev/null
+/bin/ln -s /tmp /var/tmp
 
 for i in $tardirs; do
  # Only try to untar where tmpfs mounts already exist, otherwise

--- a/etc/rc.flashrd.conf
+++ b/etc/rc.flashrd.conf
@@ -7,7 +7,7 @@
 . /etc/rc.flashrd.sub
 
 # ensure /var is conform to OpenBSD standard
-mtree -def /etc/mtree/flashrd.conf -u
+mtree -def /etc/mtree/flashrd.conf -u >/dev/null
 
 for i in $tardirs; do
  # Only try to untar where tmpfs mounts already exist, otherwise

--- a/etc/rc.flashrd.conf
+++ b/etc/rc.flashrd.conf
@@ -8,7 +8,7 @@
 
 # ensure /var is conform to OpenBSD standard
 mtree -def /etc/mtree/flashrd.conf -u >/dev/null
-/bin/ln -s /tmp /var/tmp
+/bin/ln -s /var/tmp /tmp
 
 for i in $tardirs; do
  # Only try to untar where tmpfs mounts already exist, otherwise

--- a/flashrd.sub
+++ b/flashrd.sub
@@ -58,7 +58,7 @@ umountwait() {
 
 t2() {
  if [ -z "$1" ]; then
-  usage
+  echo "t2: argument missing"
   exit 1
  fi
 }
@@ -90,4 +90,20 @@ getavailvnd() {
    echo "Not enough vnd device(s) available (${#vndevices[@]} < $1)"
    exit 1
  fi
+}
+
+###
+#
+# Return a directory tree size in blocks
+
+getsize() {
+  if [ -z "$1" ]; then
+    echo "getsize: argument missing"
+  fi
+  if [ ! -d "$1" ]; then
+    echo "getsize: the argument must be a directory"
+  fi
+  unset BLOCKSIZE
+  set -- $(du -s $1)
+  echo $1
 }

--- a/mkdist
+++ b/mkdist
@@ -254,8 +254,7 @@ for i in $vnddirs; do
 
  echo -n Analyzing /$i
 
- set -- $(c 0 du -s $distloc/$i)
- size=$1
+ size=$(c 0 getsize $distloc/$i)
 
  # du outputs 512 byte blocks
  [[ $factor -gt 1 ]] && ((size /= factor))
@@ -376,8 +375,7 @@ if [ ! -z "$tardirs" ]; then
  for tl in $tardirs; do
   echo -n Creating ${tl}.tar
 
-  set -- $(c 0 du -s $distloc/${tl})
-  size=$1
+  size=$(c 0 getsize $distloc/${tl})
   if [ `sectors2mbytes $size` -ge 1 ]; then
    echo -n " `sectors2mbytes $size`"MB files
   else

--- a/mkdist
+++ b/mkdist
@@ -115,6 +115,7 @@ configetc() {
  c ${3} echo '/etc/rc.flashrd.shutdown' >> ${1}/rc.shutdown
  c ${3} cp etc/rc.flashrd.conf etc/rc.flashrd.onetime etc/rc.flashrd.local etc/rc.flashrd.shutdown etc/rc.flashrd.sub ${1}/
 
+ c ${3} cp etc/mtree.flashrd.conf ${1}/mtree/flashrd.conf
  c ${3} mv ${tmpfstab} ${1}/fstab
 
  c ${3} "echo ${vers} > ${1}/.flashrd_version"


### PR DESCRIPTION
This fix a problem when the user building a `flashrd` image has the environment variable `BLOCKSIZE` defined.

`mkdist` rely on `du(1)` returning sizes in blocks.