### PR TITLE
Explicitly enable TMPFS 

### DIFF
--- a/mkkern
+++ b/mkkern
@@ -92,6 +92,7 @@ fi
 #	echo "option	NKL2_KIMG_ENTRIES=16" >> $kernsrc/conf/FLASHRD
 #fi
 cat >> $kernsrc/conf/FLASHRD <<-EOF
+	option  TMPFS
 	option	RAMDISK_HOOKS
 	option	MINIROOTSIZE=$blocks
 	config	bsd	root on rd0a swap on rd0b and wd0b and sd0b


### PR DESCRIPTION
Since TMPFS is no longer enabled by default for OpenBSD >= 6 we must manually enable it.